### PR TITLE
Restore console colours on Grunt task output

### DIFF
--- a/plugin/grunt.vim
+++ b/plugin/grunt.vim
@@ -33,7 +33,7 @@ let s:dirname=expand('<sfile>:h:h')
 
 " spawn helper, basic wrapper to :!
 function! s:Grunt(bang, args)
-  let cmd = 'grunt --no-color '.a:args
+  let cmd = 'grunt '.a:args
   execute ':!'.cmd
 endfunction
 


### PR DESCRIPTION
Satisfy #4 to turn on colours in Grunt output for better readability esp. in complex outputs
